### PR TITLE
Fix pathSpec regex to include hyphen

### DIFF
--- a/asset/handler.go
+++ b/asset/handler.go
@@ -10,7 +10,7 @@ import (
 
 const pathBase = "/asset/"
 
-var pathSpec = regexp.MustCompile(`^([\w=]+)/[\w\.+-]+$`)
+var pathSpec = regexp.MustCompile(`^([\w=_\-]+)/[\w\.+\-]+$`)
 
 type handler struct {
 	makeGHv4Client util.GHv4ClientMaker


### PR DESCRIPTION
Asset IDs may include a hyphen character, this PR adjusts the regex used for pattern matching the path. It also adds an `_` underscore just to be sure it matches.